### PR TITLE
Fix #9 Timezone error when calculating age of scan

### DIFF
--- a/httpobscli/cli.py
+++ b/httpobscli/cli.py
@@ -8,6 +8,7 @@ from sys import exit
 
 import argparse
 import datetime
+import pytz
 import json
 import requests
 import sys
@@ -61,7 +62,13 @@ def analyze(host):
 
     # Print out a notification on stderr that it's a cached result
     # I hate working with datetime so much
-    differential = datetime.datetime.now() - datetime.datetime.strptime(scan['end_time'], '%a, %d %b %Y %H:%M:%S %Z')
+    differential = datetime.datetime.now(pytz.utc) - \
+                   pytz.timezone('GMT').localize(
+                       datetime.datetime.strptime(
+                           scan['end_time'],
+                           '%a, %d %b %Y %H:%M:%S %Z'
+                        )
+                    )
     differential = differential.days * 86400 + differential.seconds
 
     if differential > 300:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+pytz

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     license='MPL 2.0',
     long_description=README,
     install_requires=[
-        'requests'
+        'requests',
+        'pytz'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Adds pytz as a dependency, this was necessary since datetime apparently does not contain any tzinfo instances and it is better than reinventing the wheel.

The problem was that apparently datetime.strptime does not create timezone-aware datetime objects even when %Z (timezone name) is used as part of the format string. datetime.now() without tzinfo parameter creates a timezone-naive datetime object as well but defaults to local time for the actual values instead of the more sensible UTC.

As a further suggestion for latter improvements I would suggest formatting the dates in the API as ISO8601 dates instead of the current ones which contain localized weekday and month names. I did not do this for now since i did not want to modify multiple components for this PR.
